### PR TITLE
Add playtime, wool pickups and wool placements to stats

### DIFF
--- a/models/minecraft.js
+++ b/models/minecraft.js
@@ -53,6 +53,7 @@ var MinecraftUser = new Schema({
 
     initialJoinDate         : Number,
     lastOnlineDate          : Number,
+    totalPlaytime           : Number,
 
     ranks                   : [ObjectId],
     ips                     : [String],
@@ -66,15 +67,17 @@ var MinecraftUser = new Schema({
     matches                 : [ObjectId],
     
     wool_destroys           : Number,
+    wool_pickups            : Number,
+    wool_placements         : Number,
     punishments             : [MinecraftPunishment]
 });
 MinecraftUser.methods.toJSON = function() {
     let obj = this.toObject();
     delete obj.password;
     delete obj.ips;
-    obj.level = parseInt(0.6 * Math.sqrt(((obj.wins ? obj.wins : 0) * 10) + ((obj.losses ? obj.losses : 0) * 5) + ((obj.wool_destroys ? obj.wool_destroys : 0) * 3) + ((obj.kills ? obj.kills : 0) * 2)), 10) + 1
-    obj.levelRaw = 0.6 * Math.sqrt(((obj.wins ? obj.wins : 0) * 10) + ((obj.losses ? obj.losses : 0) * 5) + ((obj.wool_destroys ? obj.wool_destroys : 0) * 3) + ((obj.kills ? obj.kills : 0) * 2)) + 1
-    obj.xp = ((obj.wins ? obj.wins : 0) * 10) + ((obj.losses ? obj.losses : 0) * 5) + ((obj.wool_destroys ? obj.wool_destroys : 0) * 3) + ((obj.kills ? obj.kills : 0) * 2);
+    obj.level = parseInt(0.6 * Math.sqrt(((obj.wins ? obj.wins : 0) * 10) + ((obj.losses ? obj.losses : 0) * 5) + ((obj.wool_destroys ? obj.wool_destroys : 0) * 3) + ((obj.wool_pickups ? obj.wool_pickups : 0) * 3) + ((obj.wool_placements ? obj.wool_placements : 0) * 12) + ((obj.kills ? obj.kills : 0) * 2)), 10) + 1
+    obj.levelRaw = 0.6 * Math.sqrt(((obj.wins ? obj.wins : 0) * 10) + ((obj.losses ? obj.losses : 0) * 5) + ((obj.wool_destroys ? obj.wool_destroys : 0) * 3) + ((obj.wool_pickups ? obj.wool_pickups : 0) * 3) + ((obj.wool_placements ? obj.wool_placements : 0) * 12) + ((obj.kills ? obj.kills : 0) * 2)) + 1
+    obj.xp = ((obj.wins ? obj.wins : 0) * 10) + ((obj.losses ? obj.losses : 0) * 5) + ((obj.wool_destroys ? obj.wool_destroys : 0) * 3) + ((obj.wool_pickups ? obj.wool_pickups : 0) * 3) + ((obj.wool_placements ? obj.wool_placements : 0) * 12) + ((obj.kills ? obj.kills : 0) * 2);
     return obj;
 };
 

--- a/routes/minecraft/matches.js
+++ b/routes/minecraft/matches.js
@@ -21,6 +21,28 @@ module.exports = function (app) {
     })
 
     /**
+     * Increments user's wool pickup count by 1.
+     *
+     * Called when user picks up a wool mid-match.
+     */
+    app.post('/mc/match/pickup_wool', verifyServer, (req, res) => {
+        MinecraftUser.update({ uuid: req.body.uuid }, { $inc: { wool_pickups: 1} }, (err) => {
+            res.json({});
+        })
+    })
+
+    /**
+     * Increments user's wool placement count by 1.
+     *
+     * Called when user places a wool mid-match.
+     */
+    app.post('/mc/match/place_wool', verifyServer, (req, res) => {
+        MinecraftUser.update({ uuid: req.body.uuid }, { $inc: { wool_placements: 1} }, (err) => {
+            res.json({});
+        })
+    })
+
+    /**
      * body: MatchLoadRequest.java
      */
     app.post('/mc/match/load', verifyServer, function(req, res) {


### PR DESCRIPTION
Add playtime, wool pickups and wool placements to stats

Playtime can be viewed by the /stats command

Tested, works 100% without errors (TGM and its API). Levels and XP are the same on the API as shown in-game.

I also added XP for wool pickups and placements, since it's an objective. Since the average DTW map on Warzone gives you 3 XP per wool, and there are 10 wools, I made wool pickups give you 3 XP and placements 12 XP, so two wools per CTW map would give you in total 30 XP, like DTW maps.